### PR TITLE
Добавление mock-эндпоинта `/forecast`

### DIFF
--- a/alembic/versions/adf9d8876a58_add_city_model_and_reference_to_it_in_.py
+++ b/alembic/versions/adf9d8876a58_add_city_model_and_reference_to_it_in_.py
@@ -5,11 +5,11 @@ Revises: 12e13727f62d
 Create Date: 2026-05-06 13:39:22.316798
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = "adf9d8876a58"

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
-from fastapi import FastAPI
-from typing import Any
+from fastapi import FastAPI, Query
+from typing import Any, Annotated, Dict
 from app import db
+from datetime import date
 from app.core.logging import setup_logging
 
 setup_logging()
@@ -20,3 +21,14 @@ def root():
 def check_db() -> dict[str, Any]:
     result: db.DatabaseHealthResponse = db.check_db()
     return result.to_dict()
+
+
+# Example: GET /forecast?time=2026-05-06&params=temperature&params=humidity&params=wind
+@app.get("/forecast")
+def get_forecast(
+    time: Annotated[date, Query()], params: list[str] = Query()
+) -> dict[str, Any]:
+    result: Dict[str, Any] = {}
+    result["time"] = time
+    result["params"] = params
+    return result


### PR DESCRIPTION
Добавление простой версии mock-эндпоинта `forecast` согласно [задаче](https://github.com/alekselu/weather_forecast/issues/29)
Пример тестирования: 
```
curl "http://localhost:8000/forecast?time=2026-05-06&params=temperature&params=humidity&params=wind"
```